### PR TITLE
Fixed implicit conversion of `crate::Error` to `anyhow::Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 2022-09-07 -- 2.3.1
+
+Fixed implicit conversion of `crate::Error` to `anyhow::Error`.
+
 ## 2022-09-05 -- 2.3.0
 
 Enhancements:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "irx-config"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 authors = ["Andriy Bakay <andriy@irbisx.com>"]
 description = "The library provides convenient way to represent/parse configuration from different sources"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,10 @@ use std::result::Result as StdResult;
 /// A result type with internal error.
 pub type Result<T> = StdResult<T, Error>;
 
+type AnyError = Box<dyn StdError + Send + Sync + 'static>;
+
 /// A result type with any error.
-pub type AnyResult<T> = StdResult<T, Box<dyn StdError>>;
+pub type AnyResult<T> = StdResult<T, AnyError>;
 
 type CowString<'a> = Cow<'a, str>;
 type AnyParser = Box<dyn Parse>;
@@ -39,7 +41,7 @@ pub enum Error {
     #[error("Failed to serialize/deserialize")]
     SerdeError(#[from] SerdeError),
     #[error("Failed to parse value")]
-    ParseValue(#[from] Box<dyn StdError>),
+    ParseValue(#[from] AnyError),
     #[error(transparent)]
     IO(#[from] std::io::Error),
 }


### PR DESCRIPTION
Closes #10.