### PR TITLE
Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # ChangeLog
 
+## 2022-09-13 -- 2.4.0
+
+Changes:
+
+* Upgrade [clap](https://docs.rs/clap/) dependency to the next minor version `3.2.x`.
+* Upgrade [serde_yaml](https://docs.rs/serde_yaml/) dependency to the next minor version `0.9.x`.
+* Upgrade [derive_builder](https://docs.rs/derive_builder/) dependency to the next minor version `0.11.x`.
+* Added a new setting `use_arg_types` to `cmd` parser. If that setting is set to `true` then use `ArgAction` or `ValueParser` type to calculate type of an argument. Default is `false`.
+
 ## 2022-09-09 -- 2.3.2
 
 Fixed issue for `use_value_delimiter` with single value in `cmd` parser.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "irx-config"
-version = "2.3.2"
+version = "2.4.0"
 edition = "2021"
 authors = ["Andriy Bakay <andriy@irbisx.com>"]
 description = "The library provides convenient way to represent/parse configuration from different sources"
@@ -26,10 +26,10 @@ thiserror = "1.0"
 serde = { version = "1.0" }
 serde_json = "1.0"
 blake2b_simd = "1.0"
-derive_builder = { version = "0.10", optional = true }
-serde_yaml = { version = "0.8", optional = true }
+derive_builder = { version = "0.11", optional = true }
+serde_yaml = { version = "0.9", optional = true }
 toml = { version = "0.5", optional = true }
-clap = { version = "3.1", optional = true }
+clap = { version = "3.2", optional = true }
 json5 = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -306,7 +306,7 @@ mod config {
 
     #[test]
     fn display_debug() -> AnyResult<()> {
-        let expected = r#"Config { parsers: size(1), value: Value { value: Object({"connections": Object({"node-1": String("tcp://node-1"), "node-2": String("tcp://node-2")}), "settings": Object({"id": Number(2), "logger": String("from second"), "name": String("node-2")})}), sealed: None, sealed_state: On, case_on: true }, case_on: true, hash: Hash(0x3b60528a5998a64869665a652c6c483ed448c1ca752115285049986c91ad28b68c76e90decb141e9d79d1fb26aea80b21c262b1b74fe39863ff461516272631f), sealed_suffix: "", keys_delimiter: ":" }"#;
+        let expected = r#"Config { parsers: size(1), value: Value { value: Object {"connections": Object {"node-1": String("tcp://node-1"), "node-2": String("tcp://node-2")}, "settings": Object {"id": Number(2), "logger": String("from second"), "name": String("node-2")}}, sealed: None, sealed_state: On, case_on: true }, case_on: true, hash: Hash(0x3b60528a5998a64869665a652c6c483ed448c1ca752115285049986c91ad28b68c76e90decb141e9d79d1fb26aea80b21c262b1b74fe39863ff461516272631f), sealed_suffix: "", keys_delimiter: ":" }"#;
         let conf = ConfigBuilder::load_one(JsonStringParser::new(SETTINGS_SECOND))?;
         println!("{:?}", conf);
         assert_eq!(expected, format!("{:?}", conf));
@@ -579,7 +579,7 @@ mod value {
         value.seal("_sealed_").set_by_key_path("settings:id", 42)?;
 
         let expected =
-            r#"Value { value: Object({}), sealed: None, sealed_state: Mutated, case_on: true }"#;
+            r#"Value { value: Object {}, sealed: None, sealed_state: Mutated, case_on: true }"#;
         let value = format!("{:?}", value);
         println!("value: {}", value);
         assert_eq!(expected, value);


### PR DESCRIPTION
* Upgrade [clap](https://docs.rs/clap/) dependency to the next minor version `3.2.x`.
* Upgrade [serde_yaml](https://docs.rs/serde_yaml/) dependency to the next minor version `0.9.x`.
* Upgrade [derive_builder](https://docs.rs/derive_builder/) dependency to the next minor version `0.11.x`.
* Added a new setting `use_arg_types` to `cmd` parser. If that setting is set to `true` then use `ArgAction` or `ValueParser` type to calculate type of an argument. Default is `false`.