### PR TITLE
Changes for 3.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog
 
+## 2022-10-06 -- 3.0.0
+
+Changes:
+
+* Upgrade [clap](https://docs.rs/clap/) dependency to the next major version `4.0.x`.
+* Remove `single_flags_as_bool` setting from `cmd` parser. That functionality should be achieved via `clap::ArgAction`.
+* The default value of `use_arg_types` settings was changed to `true`.
+
 ## 2022-09-13 -- 2.4.0
 
 Changes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "irx-config"
-version = "2.4.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["Andriy Bakay <andriy@irbisx.com>"]
 description = "The library provides convenient way to represent/parse configuration from different sources"
@@ -29,11 +29,12 @@ blake2b_simd = "1.0"
 derive_builder = { version = "0.11", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 toml = { version = "0.5", optional = true }
-clap = { version = "3.2", optional = true }
+clap = { version = "4.0", optional = true }
 json5 = { version = "0.4", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
+version-sync = "0.9"
 
 [features]
 parsers = ["derive_builder"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "2.2", features = ["env", "json"] }
+irx-config = { version = "3.0", features = ["env", "json"] }
 ```
 
 ```rust
@@ -61,7 +61,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "2.2", features = ["cmd", "env", "toml-parser"] }
+irx-config = { version = "3.0", features = ["cmd", "env", "toml-parser"] }
 ```
 
 ```rust
@@ -160,7 +160,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "2.2", features = ["json"] }
+irx-config = { version = "3.0", features = ["json"] }
 ```
 
 ```rust

--- a/tests/parsers.rs
+++ b/tests/parsers.rs
@@ -1,6 +1,6 @@
 #[cfg(all(feature = "env", feature = "json", feature = "yaml", feature = "cmd"))]
 mod integration {
-    use clap::{Arg, Command};
+    use clap::{Arg, ArgAction, Command};
     use irx_config::parsers::{cmd, env, json, yaml};
     use irx_config::{json, AnyResult, ConfigBuilder, MergeCase, Value};
     use std::env as StdEnv;
@@ -35,20 +35,15 @@ mod integration {
         }
     }
 
-    fn create_app<'a>() -> Command<'a> {
+    fn create_app() -> Command {
         Command::new("test").version("1.0").args([
-            Arg::new("config")
-                .short('c')
-                .long("config")
-                .takes_value(true)
-                .required(true),
+            Arg::new("config").short('c').long("config").required(true),
             Arg::new("settings:name")
                 .short('n')
                 .long("name")
-                .takes_value(true)
                 .required(true),
-            Arg::new("logger:timeout").short('t').takes_value(true),
-            Arg::new("verbose").short('v'),
+            Arg::new("logger:timeout").short('t'),
+            Arg::new("verbose").short('v').action(ArgAction::Count),
         ])
     }
 
@@ -65,7 +60,10 @@ mod integration {
             "1000",
             "-v",
         ];
-        let cmd_parser = cmd::ParserBuilder::new(create_app()).args(args).build()?;
+        let cmd_parser = cmd::ParserBuilder::new(create_app())
+            .args(args)
+            .use_arg_types(false)
+            .build()?;
 
         let yaml_path = resource_path!("config.yaml");
 

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,0 +1,14 @@
+#[test]
+fn test_readme_deps() {
+    version_sync::assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}
+
+#[test]
+fn test_changelog_mentions_version() {
+    version_sync::assert_contains_regex!("CHANGELOG.md", "^## [0-9]{4}-[01][0-9]-[0-3][0-9] -- {version}");
+}


### PR DESCRIPTION
* Upgrade [clap](https://docs.rs/clap/) dependency to the next major version `4.0.x` (closed #14).
* Remove `single_flags_as_bool` setting from `cmd` parser. That functionality should be achieved via `clap::ArgAction`.
* The default value of `use_arg_types` settings was changed to `true`.