### PR TITLE
Changes for `clap` defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog
 
+## 2022-10-08 -- 3.1.0
+
+Changes:
+
+* Fixed issue with default values for `clap` command-line parameters.
+* Added a new setting `use_defaults` to `cmd` parser. Use defaults from `clap` arguments. Default is `false`.
+**IMPORTANT:** Once that setting will be set to `true` then all defined command-line parameters will have values which will override values with same key(s) from parsers which was added to `ConfigBuilder` after this parser.
+
 ## 2022-10-06 -- 3.0.0
 
 Changes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "irx-config"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 authors = ["Andriy Bakay <andriy@irbisx.com>"]
 description = "The library provides convenient way to represent/parse configuration from different sources"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.0", features = ["env", "json"] }
+irx-config = { version = "3.1", features = ["env", "json"] }
 ```
 
 ```rust
@@ -61,7 +61,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.0", features = ["cmd", "env", "toml-parser"] }
+irx-config = { version = "3.1", features = ["cmd", "env", "toml-parser"] }
 ```
 
 ```rust
@@ -160,7 +160,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.0", features = ["json"] }
+irx-config = { version = "3.1", features = ["json"] }
 ```
 
 ```rust

--- a/tests/resources/defaults.toml
+++ b/tests/resources/defaults.toml
@@ -1,0 +1,2 @@
+command = "install"
+enable = true


### PR DESCRIPTION
* Fixed issue with default values for `clap` command-line parameters (#15).
* Added a new setting `use_defaults` to `cmd` parser. Use defaults from `clap` arguments. Default is `false`. **IMPORTANT:** Once that setting will be set to `true` then all defined command-line parameters will have values which will override values with same key(s) from parsers which was added to `ConfigBuilder` after this parser.