### PR TITLE
Changes for 3.1.1:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog
 
+## 2022-12-18 -- 3.1.1
+
+Changes:
+
+* Fixed compilation/clippy warnings for `Rust 1.66.0`.
+* Upgrade [derive_builder](https://docs.rs/derive_builder/) dependency to the next minor version `0.12.x`.
+* Minor code improvements.
+
 ## 2022-10-08 -- 3.1.0
 
 Changes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "irx-config"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2021"
 authors = ["Andriy Bakay <andriy@irbisx.com>"]
 description = "The library provides convenient way to represent/parse configuration from different sources"
@@ -23,10 +23,10 @@ all-features = true
 
 [dependencies]
 thiserror = "1.0"
-serde = { version = "1.0" }
+serde = "1.0"
 serde_json = "1.0"
 blake2b_simd = "1.0"
-derive_builder = { version = "0.11", optional = true }
+derive_builder = { version = "0.12", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 toml = { version = "0.5", optional = true }
 clap = { version = "4.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# irx-config library
+
+![GitHub top language](https://img.shields.io/github/languages/top/abakay/irx-config) ![Crates.io](https://img.shields.io/crates/v/irx-config) ![Crates.io](https://img.shields.io/crates/l/irx-config) ![Crates.io](https://img.shields.io/crates/d/irx-config) ![Libraries.io dependency status for latest release](https://img.shields.io/librariesio/release/cargo/irx-config) ![docs.rs](https://img.shields.io/docsrs/irx-config)
+
 The `irx-config` library provides convenient way to represent/parse configuration from different sources. The main
 goals is to be very easy to use and to be extendable.
 
@@ -22,7 +26,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.1", features = ["env", "json"] }
+irx-config = { version = "3.1.1", features = ["env", "json"] }
 ```
 
 ```rust
@@ -61,7 +65,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.1", features = ["cmd", "env", "toml-parser"] }
+irx-config = { version = "3.1.1", features = ["cmd", "env", "toml-parser"] }
 ```
 
 ```rust
@@ -160,7 +164,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.1", features = ["json"] }
+irx-config = { version = "3.1.1", features = ["json"] }
 ```
 
 ```rust

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -35,7 +35,7 @@ pub trait Load: Case {
 /// The base structure to implement file based parsers.
 #[derive(Builder)]
 #[builder(setter(into, strip_option))]
-pub struct FileParser<L> {
+pub struct FileParser<L: Load + Default> {
     /// Set default path to the file to be parsed.
     default_path: PathBuf,
     /// Set path option name which could be used to get path value from previous parsing [`Value`] results.
@@ -48,17 +48,18 @@ pub struct FileParser<L> {
     #[builder(default = "false")]
     ignore_missing_file: bool,
     /// Set the loader structure which implements [`Load`] trait.
+    #[builder(default)]
     loader: L,
 }
 
-impl<L: Load> Case for FileParser<L> {
+impl<L: Load + Default> Case for FileParser<L> {
     #[inline]
     fn is_case_sensitive(&self) -> bool {
         self.loader.is_case_sensitive()
     }
 }
 
-impl<L: Load> Parse for FileParser<L> {
+impl<L: Load + Default> Parse for FileParser<L> {
     fn parse(&mut self, value: &Value) -> AnyResult<Value> {
         let path = if let Some(ref p) = self.path_option {
             value.get_by_key_path_with_delim(p, &self.keys_delimiter)?

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -27,8 +27,11 @@ use crate::parsers::{FileParserBuilder, Load};
 use crate::{AnyResult, Case, Value};
 use std::io::Read;
 
+/// Builder for `JSON` parser.
+pub type ParserBuilder = FileParserBuilder<LoadJson>;
+
 /// Implements [`Load`] trait for `JSON` parser.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct LoadJson;
 
 impl Case for LoadJson {}
@@ -37,17 +40,5 @@ impl Load for LoadJson {
     #[inline]
     fn load(&mut self, reader: impl Read) -> AnyResult<Value> {
         Ok(serde_json::from_reader(reader)?)
-    }
-}
-
-/// Builder for `JSON` parser.
-pub struct ParserBuilder;
-
-impl ParserBuilder {
-    /// Construct instance of `JSON` builder parser.
-    pub fn default() -> FileParserBuilder<LoadJson> {
-        let mut builder = FileParserBuilder::default();
-        builder.loader(LoadJson);
-        builder
     }
 }

--- a/src/parsers/json5.rs
+++ b/src/parsers/json5.rs
@@ -27,8 +27,11 @@ use crate::parsers::{FileParserBuilder, Load};
 use crate::{AnyResult, Case, Value};
 use std::io::Read;
 
+/// Builder for `JSON5` parser.
+pub type ParserBuilder = FileParserBuilder<LoadJson>;
+
 /// Implements [`Load`] trait for `JSON5` parser.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct LoadJson;
 
 impl Case for LoadJson {}
@@ -39,17 +42,5 @@ impl Load for LoadJson {
         let mut data = String::new();
         reader.read_to_string(&mut data)?;
         Ok(json5::from_str(&data)?)
-    }
-}
-
-/// Builder for `JSON5` parser.
-pub struct ParserBuilder;
-
-impl ParserBuilder {
-    /// Construct instance of `JSON5` builder parser.
-    pub fn default() -> FileParserBuilder<LoadJson> {
-        let mut builder = FileParserBuilder::default();
-        builder.loader(LoadJson);
-        builder
     }
 }

--- a/src/parsers/tests.rs
+++ b/src/parsers/tests.rs
@@ -82,7 +82,7 @@ mod json_test {
     #[test]
     fn parser() -> AnyResult<()> {
         let path = resource_path!("config.json");
-        let expected = fs::read_to_string(&path)?;
+        let expected = fs::read_to_string(path)?;
         let expected: Value = serde_json::from_str(&expected)?;
 
         let conf = ConfigBuilder::default()
@@ -153,7 +153,7 @@ mod json5_test {
     fn parser() -> AnyResult<()> {
         let path = resource_path!("config.json5");
         let expected_path = resource_path!("config.json");
-        let expected = fs::read_to_string(&expected_path)?;
+        let expected = fs::read_to_string(expected_path)?;
         let expected: Value = serde_json::from_str(&expected)?;
 
         let conf = ConfigBuilder::default()

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -28,8 +28,11 @@ use crate::{AnyResult, Case, Value};
 use std::io::Read;
 use toml::Value as TomlValue;
 
+/// Builder for `TOML` parser.
+pub type ParserBuilder = FileParserBuilder<LoadToml>;
+
 /// Implements [`Load`] trait for `TOML` parser.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct LoadToml;
 
 impl Case for LoadToml {}
@@ -39,18 +42,6 @@ impl Load for LoadToml {
         let mut data = String::new();
         reader.read_to_string(&mut data)?;
         Ok(Value::try_from(normalize(&mut toml::from_str(&data)?))?)
-    }
-}
-
-/// Builder for `TOML` parser.
-pub struct ParserBuilder;
-
-impl ParserBuilder {
-    /// Construct instance of `TOML` builder parser.
-    pub fn default() -> FileParserBuilder<LoadToml> {
-        let mut builder = FileParserBuilder::default();
-        builder.loader(LoadToml);
-        builder
     }
 }
 

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -27,8 +27,11 @@ use crate::parsers::{FileParserBuilder, Load};
 use crate::{AnyResult, Case, Value};
 use std::io::Read;
 
+/// Builder for `YAML` parser.
+pub type ParserBuilder = FileParserBuilder<LoadYaml>;
+
 /// Implements [`Load`] trait for `YAML` parser.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct LoadYaml;
 
 impl Case for LoadYaml {}
@@ -37,17 +40,5 @@ impl Load for LoadYaml {
     #[inline]
     fn load(&mut self, reader: impl Read) -> AnyResult<Value> {
         Ok(serde_yaml::from_reader(reader)?)
-    }
-}
-
-/// Builder for `YAML` parser.
-pub struct ParserBuilder;
-
-impl ParserBuilder {
-    /// Construct instance of `YAML` builder parser.
-    pub fn default() -> FileParserBuilder<LoadYaml> {
-        let mut builder = FileParserBuilder::default();
-        builder.loader(LoadYaml);
-        builder
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -170,7 +170,7 @@ mod config {
         let conf = ConfigBuilder::load_one(JsonStringParser::new(SETTINGS_SECOND))?;
         let expected = conf.get_value();
         println!("expected: {:?}", expected);
-        assert_eq!(*expected, conf.get_by_keys::<&[&str], _, _>(&[])?.unwrap());
+        assert_eq!(*expected, conf.get_by_keys([""; 0])?.unwrap());
         Ok(())
     }
 
@@ -217,7 +217,8 @@ mod config {
         let conf = ConfigBuilder::load_one(JsonStringParser::new(SETTINGS_SECOND))?;
         assert_eq!(
             expected,
-            conf.get_by_key_path_with_delim::<Value, _, _>("connections/node-1", "/")?.unwrap()
+            conf.get_by_key_path_with_delim::<Value, _, _>("connections/node-1", "/")?
+                .unwrap()
         );
         Ok(())
     }
@@ -226,7 +227,7 @@ mod config {
     fn get_by_key_path_longer_path() -> AnyResult<()> {
         let conf = ConfigBuilder::load_one(JsonStringParser::new(SETTINGS_SECOND))?;
         let path = "connections:node-1:box:instance".to_owned();
-        assert_eq!(None, conf.get_by_key_path::<Value, _>(&path)?);
+        assert_eq!(None, conf.get_by_key_path::<Value, _>(path)?);
         Ok(())
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -263,7 +263,7 @@ impl Value {
             }
 
             if path.is_empty() {
-                return value.get_by_keys::<&[&str], _, _>(&[]);
+                return value.get_by_keys([""; 0]);
             }
 
             value.get_by_keys(path.split(delim))
@@ -422,7 +422,7 @@ impl Value {
             }
 
             if path.is_empty() {
-                return this.set_by_keys::<&[&str], _, _>(&[], value);
+                return this.set_by_keys([""; 0], value);
             }
 
             this.set_by_keys(path.split(delim), value)


### PR DESCRIPTION
* Fixed compilation/clippy warnings for `Rust 1.66.0`.
* Upgrade [derive_builder](https://docs.rs/derive_builder/) dependency to the next minor version `0.12.x`.
* Minor code improvements.