### PR TITLE
3.2.0 Changes:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # ChangeLog
 
+## 2023-02-05 -- 3.2.0
+
+Changes:
+
+* Set `Rust` version to `1.64.0` in `Cargo.toml` file.
+* Fixed compilation/clippy warnings for `Rust 1.67.0`.
+* Upgrade [clap](https://docs.rs/clap/) dependency to the next minor version `4.1.x`.
+* Upgrade [toml](https://docs.rs/toml/) dependency to the next minor version `0.7.x`.
+* Minor code improvements.
+
 ## 2022-12-18 -- 3.1.1
 
 Changes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "irx-config"
-version = "3.1.1"
+version = "3.2.0"
 edition = "2021"
+rust-version = "1.64.0"
 authors = ["Andriy Bakay <andriy@irbisx.com>"]
 description = "The library provides convenient way to represent/parse configuration from different sources"
 license = "BSD-2-Clause"
@@ -28,8 +29,8 @@ serde_json = "1.0"
 blake2b_simd = "1.0"
 derive_builder = { version = "0.12", optional = true }
 serde_yaml = { version = "0.9", optional = true }
-toml = { version = "0.5", optional = true }
-clap = { version = "4.0", optional = true }
+toml = { version = "0.7", optional = true }
+clap = { version = "4.1", optional = true }
 json5 = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.1.1", features = ["env", "json"] }
+irx-config = { version = "3.2", features = ["env", "json"] }
 ```
 
 ```rust
@@ -65,7 +65,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.1.1", features = ["cmd", "env", "toml-parser"] }
+irx-config = { version = "3.2", features = ["cmd", "env", "toml-parser"] }
 ```
 
 ```rust
@@ -164,13 +164,17 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.1.1", features = ["json"] }
+irx-config = { version = "3.2", features = ["json"] }
 ```
 
 ```rust
 use irx_config::parsers::json;
 use irx_config::ConfigBuilder;
 use serde::Deserialize;
+
+fn localhost() -> String {
+    "localhost".into()
+}
 
 #[derive(Deserialize)]
 struct Logger {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,8 @@ use serde::de::DeserializeOwned;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
-/// Container for all parsers which will (re)load data from parsers in order in which was added to [`ConfigBuilder`].
-/// It will provide access to merged set of (re)loaded configuration parameters.
+/// Container for all parser sources which will (re)load data from a parsers in order in which they was added
+/// to [`ConfigBuilder`]. It will provide access to merged set of (re)loaded configuration parameters.
 pub struct Config {
     parsers: Vec<AnyParser>,
     value: Value,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,20 +47,15 @@ pub enum Error {
 }
 
 /// Case mode to merging keys during (re)load.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum MergeCase {
     /// Auto detect merge case mode from appended parsers.
+    #[default]
     Auto,
     /// Enforce case sensitive merge mode.
     Sensitive,
     /// Enforce case insensitive merge mode.
     Insensitive,
-}
-
-impl Default for MergeCase {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 /// A data structure that has case-sensitive or case-insensitive keys.

--- a/src/parsers/env.rs
+++ b/src/parsers/env.rs
@@ -25,8 +25,7 @@
 //!     .load()?;
 //! ```
 
-use crate::parsers::CowString;
-use crate::{AnyResult, Case, Parse, Value, DEFAULT_KEYS_SEPARATOR};
+use crate::{AnyResult, Case, CowString, Parse, Value, DEFAULT_KEYS_SEPARATOR};
 use derive_builder::Builder;
 use serde_yaml::Value as YamlValue;
 use std::env;

--- a/src/parsers/tests.rs
+++ b/src/parsers/tests.rs
@@ -217,7 +217,7 @@ mod toml_test {
                 }
             ]
         }))?;
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let conf = ConfigBuilder::load_one(
             ParserBuilder::default()
@@ -226,7 +226,7 @@ mod toml_test {
                 .build()?,
         )?;
         let calculated: Value = conf.get()?;
-        println!("calculated: {:?}", calculated);
+        println!("calculated: {calculated:?}");
 
         assert_eq!(expected, calculated);
         Ok(())
@@ -279,7 +279,7 @@ mod test_cmd {
             "debug": 1,
             "tag": ""
         }))?;
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let command = Command::new("test").args([
             Arg::new("name").short('n').long("name").required(true),
@@ -316,7 +316,7 @@ mod test_cmd {
                 .build()?,
         )?;
         let calculated = conf.get_value();
-        println!("calculated: {:?}", calculated);
+        println!("calculated: {calculated:?}");
         assert_eq!(expected, *calculated);
         Ok(())
     }
@@ -326,14 +326,14 @@ mod test_cmd {
         let expected = Value::try_from(json!({
             "users": ["joe", "john"],
         }))?;
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let command =
             Command::new("test").args([Arg::new("users").value_delimiter(',').short('u')]);
         let args = ["test", "-u", "joe,john"];
         let conf = ConfigBuilder::load_one(ParserBuilder::new(command).args(args).build()?)?;
         let calculated = conf.get_value();
-        println!("calculated: {:?}", calculated);
+        println!("calculated: {calculated:?}");
         assert_eq!(expected, *calculated);
         Ok(())
     }
@@ -343,14 +343,14 @@ mod test_cmd {
         let expected = Value::try_from(json!({
             "users": ["joe"],
         }))?;
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let command =
             Command::new("test").args([Arg::new("users").value_delimiter(',').short('u')]);
         let args = ["test", "-u", "joe"];
         let conf = ConfigBuilder::load_one(ParserBuilder::new(command).args(args).build()?)?;
         let calculated = conf.get_value();
-        println!("calculated: {:?}", calculated);
+        println!("calculated: {calculated:?}");
         assert_eq!(expected, *calculated);
         Ok(())
     }
@@ -360,14 +360,14 @@ mod test_cmd {
         let expected = Value::try_from(json!({
             "users": "joe,john",
         }))?;
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let command =
             Command::new("test").args([Arg::new("users").value_delimiter(None).short('u')]);
         let args = ["test", "-u", "joe,john"];
         let conf = ConfigBuilder::load_one(ParserBuilder::new(command).args(args).build()?)?;
         let calculated = conf.get_value();
-        println!("calculated: {:?}", calculated);
+        println!("calculated: {calculated:?}");
         assert_eq!(expected, *calculated);
         Ok(())
     }
@@ -378,7 +378,7 @@ mod test_cmd {
             "enable": true,
             "disable": false,
         }))?;
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let command = Command::new("test").args([
             Arg::new("enable").short('e').action(ArgAction::SetTrue),
@@ -387,7 +387,7 @@ mod test_cmd {
         let args = ["test", "-e", "-d"];
         let conf = ConfigBuilder::load_one(ParserBuilder::new(command).args(args).build()?)?;
         let calculated = conf.get_value();
-        println!("calculated: {:?}", calculated);
+        println!("calculated: {calculated:?}");
         assert_eq!(expected, *calculated);
         Ok(())
     }
@@ -404,7 +404,7 @@ mod test_cmd {
                 .value_parser(value_parser!(String)),
         ]);
 
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
         let conf = ConfigBuilder::load_one(
             ParserBuilder::new(command)
                 .args(args)
@@ -412,7 +412,7 @@ mod test_cmd {
                 .build()?,
         )?;
         let calculated = conf.get_value();
-        println!("calculated: {:?}", calculated);
+        println!("calculated: {calculated:?}");
         assert_eq!(expected, *calculated);
         Ok(())
     }
@@ -424,7 +424,7 @@ mod test_cmd {
             "year": ["2019", "2022"],
             "month": "1",
         }))?;
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let args = ["test", "-a", "42", "-y", "2019", "-y", "2022", "-m", "'1'"];
         arg_types(&args, expected, true)
@@ -437,7 +437,7 @@ mod test_cmd {
             "year": [2019, 2022],
             "month": "1",
         }))?;
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let args = [
             "test", "-a", "42", "-y", "2019", "-y", "2022", "-m", r#""1""#,
@@ -446,7 +446,7 @@ mod test_cmd {
     }
 
     fn user_add(expected: Value, global_on: bool) -> AnyResult<()> {
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let app = create_app_with_subcmds();
         let args = [
@@ -466,7 +466,7 @@ mod test_cmd {
                 .build()?,
         )?;
         let calculated = conf.get_value();
-        println!("calculated: {:?}", calculated);
+        println!("calculated: {calculated:?}");
         assert_eq!(expected, *calculated);
         Ok(())
     }
@@ -506,7 +506,7 @@ mod test_cmd {
         let expected = Value::try_from(json!({
             "config": "config.toml"
         }))?;
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let command = Command::new("test").args([
             Arg::new("config").short('c'),
@@ -515,7 +515,7 @@ mod test_cmd {
         let args = ["test", "-c", "config.toml"];
         let conf = ConfigBuilder::load_one(ParserBuilder::new(command).args(args).build()?)?;
         let calculated = conf.get_value();
-        println!("calculated: {:?}", calculated);
+        println!("calculated: {calculated:?}");
         assert_eq!(expected, *calculated);
         Ok(())
     }
@@ -526,7 +526,7 @@ mod test_cmd {
             "config": "default.toml",
             "enable": false,
         }))?;
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let command = Command::new("test").args([
             Arg::new("config").short('c').default_value("default.toml"),
@@ -540,7 +540,7 @@ mod test_cmd {
                 .build()?,
         )?;
         let calculated = conf.get_value();
-        println!("calculated: {:?}", calculated);
+        println!("calculated: {calculated:?}");
         assert_eq!(expected, *calculated);
         Ok(())
     }
@@ -549,7 +549,7 @@ mod test_cmd {
         let expected = Value::try_from(json!({
             "enable": true
         }))?;
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
 
         let config_arg = if explicit {
             Arg::new("config").short('c').default_value("default.toml")
@@ -564,7 +564,7 @@ mod test_cmd {
         let args = ["test", "-e"];
         let conf = ConfigBuilder::load_one(ParserBuilder::new(command).args(args).build()?)?;
         let calculated = conf.get_value();
-        println!("calculated: {:?}", calculated);
+        println!("calculated: {calculated:?}");
         assert_eq!(expected, *calculated);
         Ok(())
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -114,8 +114,8 @@ mod config {
         let conf = ConfigBuilder::load_one(ValueParser::new(data))?;
         let person: Person = conf.get()?;
 
-        println!("Person: {:?}", person);
-        assert_eq!(format!("{:?}", expected), format!("{:?}", person));
+        println!("Person: {person:?}");
+        assert_eq!(format!("{expected:?}"), format!("{person:?}"));
         Ok(())
     }
 
@@ -137,8 +137,8 @@ mod config {
                 tag: "from third".to_owned(),
             },
         };
-        println!("{:?}", sections);
-        assert_eq!(format!("{:?}", s), format!("{:?}", sections));
+        println!("{sections:?}");
+        assert_eq!(format!("{s:?}"), format!("{sections:?}"));
         Ok(())
     }
 
@@ -154,7 +154,7 @@ mod config {
         "#;
         let conf = ConfigBuilder::load_one(JsonStringParser::new(data)).unwrap();
         let value: Value = conf.get().unwrap();
-        println!("{:?}", value);
+        println!("{value:?}");
     }
 
     #[test]
@@ -169,7 +169,7 @@ mod config {
     fn get_by_keys_empty() -> AnyResult<()> {
         let conf = ConfigBuilder::load_one(JsonStringParser::new(SETTINGS_SECOND))?;
         let expected = conf.get_value();
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
         assert_eq!(*expected, conf.get_by_keys([""; 0])?.unwrap());
         Ok(())
     }
@@ -178,7 +178,7 @@ mod config {
     fn get_by_key_path_empty() -> AnyResult<()> {
         let conf = ConfigBuilder::load_one(JsonStringParser::new(SETTINGS_SECOND))?;
         let expected = conf.get_value();
-        println!("expected: {:?}", expected);
+        println!("expected: {expected:?}");
         assert_eq!(*expected, conf.get_by_key_path("")?.unwrap());
         Ok(())
     }
@@ -254,7 +254,7 @@ mod config {
 }"#;
         let conf = ConfigBuilder::load_one(JsonStringParser::new(SETTINGS_SECOND))?;
         let conf = conf.to_string();
-        println!("{}", conf);
+        println!("{conf}");
         assert_eq!(expected, conf);
         Ok(())
     }
@@ -297,10 +297,10 @@ mod config {
             .append_parser(ValueParser::new(value))
             .load()?;
         let conf_str = serde_json::to_string_pretty(&conf.get_value())?;
-        println!("{}", conf_str);
+        println!("{conf_str}");
         assert_eq!(serde_json::to_string_pretty(&exp_value)?, conf_str);
         let conf = conf.to_string();
-        println!("{}", conf);
+        println!("{conf}");
         assert_eq!(expected, conf);
         Ok(())
     }
@@ -309,8 +309,8 @@ mod config {
     fn display_debug() -> AnyResult<()> {
         let expected = r#"Config { parsers: size(1), value: Value { value: Object {"connections": Object {"node-1": String("tcp://node-1"), "node-2": String("tcp://node-2")}, "settings": Object {"id": Number(2), "logger": String("from second"), "name": String("node-2")}}, sealed: None, sealed_state: On, case_on: true }, case_on: true, hash: Hash(0x3b60528a5998a64869665a652c6c483ed448c1ca752115285049986c91ad28b68c76e90decb141e9d79d1fb26aea80b21c262b1b74fe39863ff461516272631f), sealed_suffix: "", keys_delimiter: ":" }"#;
         let conf = ConfigBuilder::load_one(JsonStringParser::new(SETTINGS_SECOND))?;
-        println!("{:?}", conf);
-        assert_eq!(expected, format!("{:?}", conf));
+        println!("{conf:?}");
+        assert_eq!(expected, format!("{conf:?}"));
         Ok(())
     }
 
@@ -349,10 +349,10 @@ mod config {
             .append_parser(ValueParser::new(value))
             .load()?;
         let conf_str = serde_json::to_string_pretty(&conf.get_value())?;
-        println!("{}", conf_str);
+        println!("{conf_str}");
         assert_eq!(serde_json::to_string_pretty(&exp_value)?, conf_str);
         let conf = conf.to_string();
-        println!("{}", conf);
+        println!("{conf}");
         assert_eq!(expected, conf);
         Ok(())
     }
@@ -410,7 +410,7 @@ mod value {
         }))?;
 
         value = value.merge(&dummy);
-        println!("value: {:?}", value);
+        println!("value: {value:?}");
 
         assert!(!value.is_sealed());
         Ok(())
@@ -426,7 +426,7 @@ mod value {
         let dummy = Value::try_from(json!(""))?;
 
         value = value.merge(&dummy);
-        println!("value: {:?}", value);
+        println!("value: {value:?}");
 
         assert!(value.is_sealed());
         Ok(())
@@ -456,7 +456,7 @@ mod value {
         }))?;
 
         person = person.merge(&phones);
-        println!("person: {}", person);
+        println!("person: {person}");
         assert_eq!(expected, person);
         Ok(())
     }
@@ -506,9 +506,9 @@ mod value {
         let prev = value.set_by_key_path("", 42)?.unwrap();
         let de_value: i32 = value.get()?;
 
-        println!("value: {:?}", value);
-        println!("value(deserialized): {:?}", de_value);
-        println!("prev: {:?}", prev);
+        println!("value: {value:?}");
+        println!("value(deserialized): {de_value:?}");
+        println!("prev: {prev:?}");
 
         assert_eq!(SealedState::Mutated, value.sealed_state());
         assert!(prev.is_sealed());
@@ -548,8 +548,8 @@ mod value {
         let expected = r#"{
   "id": 42
 }"#;
-        let value = format!("{}", value);
-        println!("value: {}", value);
+        let value = format!("{value}");
+        println!("value: {value}");
         assert_eq!(expected, value);
         Ok(())
     }
@@ -559,8 +559,8 @@ mod value {
         let mut value = Value::default();
         value.seal("").set_by_key_path("id", 42)?;
         let expected = r"{}";
-        let value = format!("{}", value);
-        println!("value: {}", value);
+        let value = format!("{value}");
+        println!("value: {value}");
         assert_eq!(expected, value);
         Ok(())
     }
@@ -581,8 +581,8 @@ mod value {
 
         let expected =
             r#"Value { value: Object {}, sealed: None, sealed_state: Mutated, case_on: true }"#;
-        let value = format!("{:?}", value);
-        println!("value: {}", value);
+        let value = format!("{value:?}");
+        println!("value: {value}");
         assert_eq!(expected, value);
         Ok(())
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -19,21 +19,16 @@ type CowInnerValue<'a> = Cow<'a, InnerValue>;
 ///
 /// **IMPORTANT:** Once [`Value`] was sealed, but fully/partially mutated after that, it will be represented as empty
 /// dictionary during display/debugging output, to prevent sensitive data leakages.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SealedState {
     /// A [`Value`] was never sealed, all data will be represented as is during display/debugging output.
+    #[default]
     None,
     /// A [`Value`] was sealed, sensitive data will be obfuscated during display/debugging output.
     On,
     /// A [`Value`] was sealed and fully/partially mutated after that, whole [`Value`] will be represented as empty
     /// dictionary during display/debugging output (see above).
     Mutated,
-}
-
-impl Default for SealedState {
-    fn default() -> Self {
-        SealedState::None
-    }
 }
 
 /// This structure represent key-value based configuration data.

--- a/tests/parsers.rs
+++ b/tests/parsers.rs
@@ -1,8 +1,11 @@
 #[cfg(all(feature = "env", feature = "json", feature = "yaml", feature = "cmd"))]
 mod integration {
     use clap::{Arg, ArgAction, Command};
-    use irx_config::parsers::{cmd, env, json, toml, yaml};
-    use irx_config::{json, AnyResult, ConfigBuilder, MergeCase, Value};
+    use irx_config::{
+        json,
+        parsers::{cmd, env, json, toml, yaml},
+        AnyResult, ConfigBuilder, MergeCase, Value,
+    };
     use std::env as StdEnv;
 
     #[macro_export]
@@ -21,7 +24,7 @@ mod integration {
 
     fn format_option_bool(option: Option<bool>) -> String {
         if let Some(o) = option {
-            format!("{}", o)
+            format!("{o}")
         } else {
             "None".to_string()
         }
@@ -29,7 +32,7 @@ mod integration {
 
     fn format_option_merge_case(option: Option<MergeCase>) -> String {
         if let Some(o) = option {
-            format!("{:?}", o)
+            format!("{o:?}")
         } else {
             "None".to_string()
         }
@@ -92,7 +95,7 @@ mod integration {
             .append_parser(yaml_parser)
             .append_parser(env_parser)
             .load()?;
-        println!("{}", config);
+        println!("{config}");
         assert_eq!(expected, *config.get_value());
         Ok(())
     }
@@ -167,7 +170,7 @@ mod integration {
             builder = builder.merge_case(m)
         }
         let config = builder.load()?;
-        println!("{}", config);
+        println!("{config}");
         assert_eq!(
             expected,
             config.get_value(),
@@ -256,7 +259,7 @@ mod integration {
             .append_parser(cmd_parser)
             .append_parser(toml_parser)
             .load()?;
-        println!("{}", config);
+        println!("{config}");
         assert_eq!(expected, *config.get_value());
 
         Ok(())


### PR DESCRIPTION
* Set `Rust` version to `1.64.0` in `Cargo.toml` file.
* Fixed compilation/clippy warnings for `Rust 1.67.0`.
* Upgrade [clap](https://docs.rs/clap/) dependency to the next minor version `4.1.x`.
* Upgrade [toml](https://docs.rs/toml/) dependency to the next minor version `0.7.x`.
* Minor code improvements.