### PR TITLE
Changes for 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog
 
+## 2023-12-11 -- 3.4.0
+
+Changes:
+
+* Switch from `BLAKE2b` to `BLAKE3` hash.
+* Upgrade [clap](https://docs.rs/clap/) dependency to the next minor version `4.4.x`.
+* Upgrade [toml](https://docs.rs/toml/) dependency to the next minor version `0.8.x`.
+
 ## 2023-02-23 -- 3.3.0
 
 Changes:

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-Copyright (c) 2021, Andriy Bakay <andriy@irbisx.com>
+Copyright (c) 2021-2023, Andriy Bakay <andriy@irbisx.com>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "irx-config"
-version = "3.3.0"
+version = "3.4.0"
 edition = "2021"
 rust-version = "1.65.0"
 authors = ["Andriy Bakay <andriy@irbisx.com>"]
@@ -26,11 +26,11 @@ all-features = true
 thiserror = "1.0"
 serde = "1.0"
 serde_json = "1.0"
-blake2b_simd = "1.0"
+blake3 = "1.5"
 derive_builder = { version = "0.12", optional = true }
 serde_yaml = { version = "0.9", optional = true }
-toml = { version = "0.7", optional = true }
-clap = { version = "4.1", optional = true }
+toml = { version = "0.8", optional = true }
+clap = { version = "4.4", optional = true }
 json5 = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.3", features = ["env", "json"] }
+irx-config = { version = "3.4", features = ["env", "json"] }
 ```
 
 ```rust
@@ -65,7 +65,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.3", features = ["cmd", "env", "toml-parser"] }
+irx-config = { version = "3.4", features = ["cmd", "env", "toml-parser"] }
 ```
 
 ```rust
@@ -168,7 +168,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.3", features = ["json"] }
+irx-config = { version = "3.4", features = ["json"] }
 ```
 
 ```rust

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! This module define main configuration structures: [`Config`] and [`ConfigBuilder`].
 
 use crate::{AnyParser, Error, MergeCase, Parse, Result, Value, DEFAULT_KEYS_SEPARATOR};
-use blake2b_simd::Hash;
+use blake3::Hash;
 use serde::de::DeserializeOwned;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
@@ -33,7 +33,7 @@ impl Config {
         }
 
         value.seal(&self.sealed_suffix);
-        self.hash = blake2b_simd::blake2b(&value.as_bytes());
+        self.hash = blake3::hash(&value.as_bytes());
         self.value = value;
         Ok(self)
     }
@@ -41,7 +41,7 @@ impl Config {
     /// Calculate hash for currently loaded configuration data.
     #[inline]
     pub fn hash(&self) -> String {
-        format!("BLAKE2b: {}", self.hash.to_hex())
+        format!("BLAKE3: {}", self.hash.to_hex())
     }
 
     /// Returns configuration data value to corresponding key/nested keys.
@@ -303,7 +303,7 @@ impl ConfigBuilder {
     /// If any errors will occur during parsing/merging then error will be returned.
     pub fn load(self) -> Result<Config> {
         let value = Value::default();
-        let hash = blake2b_simd::blake2b(&value.as_bytes());
+        let hash = blake3::hash(&value.as_bytes());
         let case_on = if MergeCase::Auto == self.merge_case {
             self.auto_case_on
         } else {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -240,7 +240,7 @@ mod config {
 
     #[test]
     fn display() -> AnyResult<()> {
-        let expected = r#"Config: BLAKE2b: 3b60528a5998a64869665a652c6c483ed448c1ca752115285049986c91ad28b68c76e90decb141e9d79d1fb26aea80b21c262b1b74fe39863ff461516272631f
+        let expected = r#"Config: BLAKE3: 491cb76797a37492c3b10bbf93278b7ba568341f2f9237ba7f289956a24e1eac
 {
   "connections": {
     "node-1": "tcp://node-1",
@@ -261,7 +261,7 @@ mod config {
 
     #[test]
     fn display_sealed() -> AnyResult<()> {
-        let expected = r#"Config: BLAKE2b: 60fc9c29c18e47d1709bb584794faef76b1cedca31aba76c73cd60a23f22ca51b961ac9bbc80abca7fde1a5247ee140178d9067146aed012e2d78758b3496e01
+        let expected = r#"Config: BLAKE3: 0102dcddd8073a13d974e538331910072c0dd35bef692b291dca68479c267f40
 {
   "perm": {
     "password": "********",
@@ -307,7 +307,7 @@ mod config {
 
     #[test]
     fn display_debug() -> AnyResult<()> {
-        let expected = r#"Config { parsers: size(1), value: Value { value: Object {"connections": Object {"node-1": String("tcp://node-1"), "node-2": String("tcp://node-2")}, "settings": Object {"id": Number(2), "logger": String("from second"), "name": String("node-2")}}, sealed: None, sealed_state: On, case_on: true }, case_on: true, hash: Hash(0x3b60528a5998a64869665a652c6c483ed448c1ca752115285049986c91ad28b68c76e90decb141e9d79d1fb26aea80b21c262b1b74fe39863ff461516272631f), sealed_suffix: "", keys_delimiter: ":" }"#;
+        let expected = r#"Config { parsers: size(1), value: Value { value: Object {"connections": Object {"node-1": String("tcp://node-1"), "node-2": String("tcp://node-2")}, "settings": Object {"id": Number(2), "logger": String("from second"), "name": String("node-2")}}, sealed: None, sealed_state: On, case_on: true }, case_on: true, hash: Hash("491cb76797a37492c3b10bbf93278b7ba568341f2f9237ba7f289956a24e1eac"), sealed_suffix: "", keys_delimiter: ":" }"#;
         let conf = ConfigBuilder::load_one(JsonStringParser::new(SETTINGS_SECOND))?;
         println!("{conf:?}");
         assert_eq!(expected, format!("{conf:?}"));
@@ -316,7 +316,7 @@ mod config {
 
     #[test]
     fn display_sealed_nested() -> AnyResult<()> {
-        let expected = r#"Config: BLAKE2b: 60fc9c29c18e47d1709bb584794faef76b1cedca31aba76c73cd60a23f22ca51b961ac9bbc80abca7fde1a5247ee140178d9067146aed012e2d78758b3496e01
+        let expected = r#"Config: BLAKE3: 0102dcddd8073a13d974e538331910072c0dd35bef692b291dca68479c267f40
 {
   "perm": "********",
   "settings": {


### PR DESCRIPTION
* Switch from `BLAKE2b` to `BLAKE3` hash.
* Upgrade [clap](https://docs.rs/clap/) dependency to the next minor version `4.4.x`.
* Upgrade [toml](https://docs.rs/toml/) dependency to the next minor version `0.8.x`.