### PR TITLE
Changes:

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,12 +10,12 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-os:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [stable, beta]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        rust: [ stable, beta ]
 
     steps:
       - name: Checkout code
@@ -26,7 +26,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      
+
       - name: Cache Cargo registry
         uses: actions/cache@v4
         with:
@@ -34,7 +34,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      
+
       - name: Cache Cargo build
         uses: actions/cache@v4
         with:
@@ -49,9 +49,59 @@ jobs:
           command: build
           args: --release --all-features
 
-      - name: Test
-        if: runner.os != 'Windows'
+      - name: Test default
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --all-targets --all-features
+          args: --verbose --all-features
+
+      - name: Test blake3
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --no-default-features --features blake3,cmd,yaml,env,json,toml-parser,json5-parser
+
+  build-target:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [ x86_64-apple-darwin ]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.target }}-cargo-
+
+      - name: Cache Cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ matrix.target }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.target }}-build-
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target ${{ matrix.target }} --release --features cmd,yaml,env,json,toml-parser,json5-parser
+
+      - name: Test default
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target ${{ matrix.target }} --verbose --features cmd,yaml,env,json,toml-parser,json5-parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # ChangeLog
 
+## 2024-11-11 -- 3.5.0
+
+Changes:
+
+* Make hash configurable via crate features: `blake2b` and `blake3`. Use `blake2b` feature by default.
+* Switch to dependency namespace `dep:...` in `Cargo.toml` file.
+* Set `Rust` version to `1.74.0` in `Cargo.toml` file.
+* Upgrade [derive_builder](https://docs.rs/derive_builder/) dependency to the next minor version `0.20.x`.
+* Upgrade [clap](https://docs.rs/clap/) dependency to the next minor version `4.5.x`.
+* Disable doc tests for create's documentation.
+* Minor code cleanups.
+
 ## 2023-12-11 -- 3.4.0
 
 Changes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "irx-config"
-version = "3.4.0"
+version = "3.5.0"
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.74.0"
 authors = ["Andriy Bakay <andriy@irbisx.com>"]
 description = "The library provides convenient way to represent/parse configuration from different sources"
 license = "BSD-2-Clause"
@@ -26,11 +26,13 @@ all-features = true
 thiserror = "1.0"
 serde = "1.0"
 serde_json = "1.0"
-blake3 = "1.5"
-derive_builder = { version = "0.12", optional = true }
+cfg-if = "1.0"
+blake2b_simd = { version = "1.0", optional = true }
+blake3 = { version = "1.5", optional = true }
+derive_builder = { version = "0.20", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 toml = { version = "0.8", optional = true }
-clap = { version = "4.4", optional = true }
+clap = { version = "4.5", optional = true }
 json5 = { version = "0.4", optional = true }
 
 [dev-dependencies]
@@ -38,13 +40,19 @@ serde = { version = "1.0", features = ["derive"] }
 version-sync = "0.9"
 
 [features]
-parsers = ["derive_builder"]
-env = ["parsers", "serde_yaml"]
+default = ["blake2b"]
+blake2b = ["dep:blake2b_simd"]
+blake3 = ["dep:blake3"]
+parsers = ["dep:derive_builder"]
+env = ["parsers", "dep:serde_yaml"]
 json = ["parsers"]
-json5-parser = ["parsers", "json5"]
-yaml = ["parsers", "serde_yaml"]
-toml-parser = ["parsers", "toml"]
-cmd = ["parsers", "clap", "serde_yaml"]
+json5-parser = ["parsers", "dep:json5"]
+yaml = ["parsers", "dep:serde_yaml"]
+toml-parser = ["parsers", "dep:toml"]
+cmd = ["parsers", "dep:clap", "dep:serde_yaml"]
+
+[lib]
+doctest = false
 
 [[test]]
 name = "parsers"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # irx-config library
 
-![GitHub top language](https://img.shields.io/github/languages/top/abakay/irx-config) ![Crates.io](https://img.shields.io/crates/v/irx-config) ![Crates.io](https://img.shields.io/crates/l/irx-config) ![Crates.io](https://img.shields.io/crates/d/irx-config) ![Libraries.io dependency status for latest release](https://img.shields.io/librariesio/release/cargo/irx-config) ![docs.rs](https://img.shields.io/docsrs/irx-config)
+![GitHub top language](https://img.shields.io/github/languages/top/abakay/irx-config) ![Crates.io](https://img.shields.io/crates/v/irx-config) ![Crates.io](https://img.shields.io/crates/l/irx-config) ![Crates.io](https://img.shields.io/crates/d/irx-config) ![Libraries.io dependency status for latest release](https://img.shields.io/librariesio/release/cargo/irx-config) ![docs.rs](https://img.shields.io/docsrs/irx-config) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/abakay/irx-config/rust.yml)
 
 The `irx-config` library provides convenient way to represent/parse configuration from different sources. The main
 goals is to be very easy to use and to be extendable.
@@ -26,7 +26,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.4", features = ["env", "json"] }
+irx-config = { version = "3.5", features = ["env", "json"] }
 ```
 
 ```rust
@@ -65,7 +65,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.4", features = ["cmd", "env", "toml-parser"] }
+irx-config = { version = "3.5", features = ["cmd", "env", "toml-parser"] }
 ```
 
 ```rust
@@ -168,7 +168,7 @@ To enable parsers used in example below, one has to add the following to `Cargo.
 
 ```toml
 [dependencies]
-irx-config = { version = "3.4", features = ["json"] }
+irx-config = { version = "3.5", features = ["json"] }
 ```
 
 ```rust

--- a/src/parsers/cmd.rs
+++ b/src/parsers/cmd.rs
@@ -16,7 +16,7 @@
 //! be merged accordingly with other parsers results. Such nested keys structure(s) will represent
 //! sub dictionaries/sections.
 //!
-//! ```no_run
+//! ```
 //! use clap::{command, Arg};
 //! use irx_config::ConfigBuilder;
 //! use irx_config::parsers::cmd::ParserBuilder;
@@ -33,7 +33,7 @@
 //! subcommand(s) then arguments names for each subcommand will be prefixed with given subcommand's name and keys
 //! delimiter. The `global key names` feature is on by default.
 //!
-//! ```no_run
+//! ```
 //! use clap::{command, Command, Arg};
 //! use irx_config::ConfigBuilder;
 //! use irx_config::parsers::cmd::ParserBuilder;
@@ -225,7 +225,7 @@ impl ParserBuilder {
         if let Some(ref args) = self.args {
             self.command.try_get_matches_from_mut(args)
         } else {
-            self.command.try_get_matches_from_mut(&mut env::args_os())
+            self.command.try_get_matches_from_mut(env::args_os())
         }
     }
 

--- a/src/parsers/env.rs
+++ b/src/parsers/env.rs
@@ -11,7 +11,7 @@
 //!
 //! # Example
 //!
-//! ```no_run
+//! ```
 //! use irx_config::ConfigBuilder;
 //! use irx_config::parsers::env::ParserBuilder;
 //!

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -9,7 +9,7 @@
 //!
 //! # Example
 //!
-//! ```no_run
+//! ```
 //! use irx_config::ConfigBuilder;
 //! use irx_config::parsers::json::ParserBuilder;
 //!

--- a/src/parsers/json5.rs
+++ b/src/parsers/json5.rs
@@ -9,7 +9,7 @@
 //!
 //! # Example
 //!
-//! ```no_run
+//! ```
 //! use irx_config::ConfigBuilder;
 //! use irx_config::parsers::json5::ParserBuilder;
 //!

--- a/src/parsers/tests.rs
+++ b/src/parsers/tests.rs
@@ -128,8 +128,6 @@ mod json_test {
             .unwrap();
     }
 
-    #[test]
-    #[should_panic(expected = "NotAFile")]
     fn parse_not_a_file() {
         ConfigBuilder::default()
             .append_parser(
@@ -141,6 +139,20 @@ mod json_test {
             )
             .load()
             .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "NotAFile")]
+    #[cfg_attr(windows, ignore)]
+    fn parse_not_a_file_unix() {
+        parse_not_a_file()
+    }
+
+    #[test]
+    #[should_panic(expected = "Access is denied")]
+    #[cfg_attr(unix, ignore)]
+    fn parse_not_a_file_windows() {
+        parse_not_a_file()
     }
 }
 

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -9,7 +9,7 @@
 //!
 //! # Example
 //!
-//! ```no_run
+//! ```
 //! use irx_config::ConfigBuilder;
 //! use irx_config::parsers::toml::ParserBuilder;
 //!

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -9,7 +9,7 @@
 //!
 //! # Example
 //!
-//! ```no_run
+//! ```
 //! use irx_config::ConfigBuilder;
 //! use irx_config::parsers::yaml::ParserBuilder;
 //!

--- a/src/value.rs
+++ b/src/value.rs
@@ -53,7 +53,7 @@ impl Value {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use irx_config::{json, Value};
     ///
     /// let data = Value::try_from(json!(
@@ -107,7 +107,7 @@ impl Value {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use irx_config::{json, Value};
     ///
     /// let mut person = Value::try_from(json!({
@@ -158,7 +158,7 @@ impl Value {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use irx_config::{json, Value};
     ///
     /// let logger = Value::try_from(json!({
@@ -202,7 +202,7 @@ impl Value {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use irx_config::{json, Value};
     ///
     /// let logger = Value::try_from(json!({
@@ -232,7 +232,7 @@ impl Value {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use irx_config::{json, Value};
     ///
     /// let logger = Value::try_from(json!({
@@ -276,7 +276,7 @@ impl Value {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use irx_config::{json, Value};
     /// use serde::Deserialize;
     ///
@@ -315,7 +315,7 @@ impl Value {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use irx_config::Value;
     ///
     /// let mut value = Value::default();
@@ -367,7 +367,7 @@ impl Value {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use irx_config::Value;
     ///
     /// let mut value = Value::default();
@@ -392,7 +392,7 @@ impl Value {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use irx_config::Value;
     ///
     /// let mut value = Value::default();
@@ -438,7 +438,7 @@ impl Value {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use irx_config::Value;
     ///
     /// let mut value = Value::try_from(json!({


### PR DESCRIPTION
* Make hash configurable via crate features: `blake2b` and `blake3`. Use `blake2b` feature by default.
* Switch to dependency namespace `dep:...` in `Cargo.toml` file.
* Set `Rust` version to `1.74.0` in `Cargo.toml` file.
* Upgrade [derive_builder](https://docs.rs/derive_builder/) dependency to the next minor version `0.20.x`.
* Upgrade [clap](https://docs.rs/clap/) dependency to the next minor version `4.5.x`.
* Disable doc tests for create's documentation.
* Minor code cleanups.